### PR TITLE
Add `AllocationGroupId`.

### DIFF
--- a/benches/overhead.rs
+++ b/benches/overhead.rs
@@ -1,7 +1,7 @@
 use std::{alloc::System, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use tracking_allocator::{AllocationRegistry, AllocationTracker, Allocator};
+use tracking_allocator::{AllocationGroupId, AllocationRegistry, AllocationTracker, Allocator};
 
 // Every benchmark will now run through the tracking allocator.  All we're measuring here is the
 // various amounts of overhead depending on whether an allocation tracker is set, whether or not
@@ -17,7 +17,7 @@ impl AllocationTracker for NoopTracker {
         &self,
         _addr: usize,
         _size: usize,
-        _group_id: usize,
+        _group_id: AllocationGroupId,
         _tags: Option<&'static [(&'static str, &'static str)]>,
     ) {
     }

--- a/examples/stdout.rs
+++ b/examples/stdout.rs
@@ -1,4 +1,10 @@
-use tracking_allocator::{AllocationGroupToken, AllocationRegistry, AllocationTracker, Allocator};
+use tracking_allocator::{
+    AllocationGroupId,
+    AllocationGroupToken,
+    AllocationRegistry,
+    AllocationTracker,
+    Allocator,
+};
 
 use std::{
     alloc::System,
@@ -21,7 +27,7 @@ enum AllocationEvent {
     Allocated {
         addr: usize,
         size: usize,
-        group_id: usize,
+        group_id: AllocationGroupId,
         tags: Option<&'static [(&'static str, &'static str)]>,
     },
     Deallocated {
@@ -52,7 +58,7 @@ impl AllocationTracker for ChannelBackedTracker {
         &self,
         addr: usize,
         size: usize,
-        group_id: usize,
+        group_id: AllocationGroupId,
         tags: Option<&'static [(&'static str, &'static str)]>,
     ) {
         // Allocations have all the pertinent information upfront, which you must store if you want
@@ -145,7 +151,7 @@ fn main() {
                 tags,
             } => {
                 println!(
-                    "allocation -> addr={:#x} size={} group_id={} tags={:?}",
+                    "allocation -> addr={:#x} size={} group_id={:?} tags={:?}",
                     addr, size, group_id, tags
                 );
             }

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -5,7 +5,12 @@ use tokio::{
 use tracing::{info_span, Instrument};
 use tracing_subscriber::{layer::SubscriberExt, Registry};
 use tracking_allocator::{
-    AllocationGroupToken, AllocationLayer, AllocationRegistry, AllocationTracker, Allocator,
+    AllocationGroupId,
+    AllocationGroupToken,
+    AllocationLayer,
+    AllocationRegistry,
+    AllocationTracker,
+    Allocator,
 };
 
 use std::{
@@ -35,7 +40,7 @@ enum AllocationEvent {
     Allocated {
         addr: usize,
         size: usize,
-        group_id: usize,
+        group_id: AllocationGroupId,
         tags: Option<&'static [(&'static str, &'static str)]>,
     },
     Deallocated {
@@ -66,7 +71,7 @@ impl AllocationTracker for ChannelBackedTracker {
         &self,
         addr: usize,
         size: usize,
-        group_id: usize,
+        group_id: AllocationGroupId,
         tags: Option<&'static [(&'static str, &'static str)]>,
     ) {
         // Allocations have all the pertinent information upfront, which you must store if you want
@@ -121,7 +126,7 @@ fn main() {
                         tags,
                     } => {
                         println!(
-                            "allocation -> addr={:#x} size={} group_id={} tags={:?}",
+                            "allocation -> addr={:#x} size={} group_id={:?} tags={:?}",
                             addr, size, group_id, tags
                         );
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod tracing;
 mod util;
 
 pub use crate::allocator::Allocator;
-pub use crate::token::{AllocationGroupToken, AllocationGuard};
+pub use crate::token::{AllocationGroupId, AllocationGroupToken, AllocationGuard};
 #[cfg(feature = "tracing-compat")]
 pub use crate::tracing::AllocationLayer;
 
@@ -89,7 +89,7 @@ pub trait AllocationTracker {
         &self,
         addr: usize,
         size: usize,
-        group_id: usize,
+        group_id: AllocationGroupId,
         tags: Option<&'static [(&'static str, &'static str)]>,
     );
 
@@ -130,7 +130,7 @@ impl Tracker {
         &self,
         addr: usize,
         size: usize,
-        group_id: usize,
+        group_id: AllocationGroupId,
         tags: Option<&'static [(&'static str, &'static str)]>,
     ) {
         self.tracker.allocated(addr, size, group_id, tags)


### PR DESCRIPTION
This PR allows users to correlate between the `group_id` of allocation events and `AllocationGroupToken`. Specifically:
- A new `AllocationGroupToken::id` method turns an `AllocationGroupToken` into an `AllocationGroupId`.
- The `group_id` parameter of `AllocationTracker::allocated` is now a `AllocationGroupId`.

Unlike `AllocationGroupToken`, the `AllocationGroupId` type may be freely copied, compared and hashed.