### PR TITLE
When `tracing-compat`, also require `tracing-subscriber/std` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["tracing-compat"]
 
 [features]
 default = ["tracing-compat"]
-tracing-compat = ["tracing", "tracing-subscriber"]
+tracing-compat = ["tracing", "tracing-subscriber", "tracing-subscriber/std"]
 
 [dependencies] 
 tracing = { version = "0.1", default-features = false,  optional = true }


### PR DESCRIPTION
This feature is required to call `.extensions_mut` on a SpanRef.

Without this change, I was getting a compile error trying to build tracking-allocator as a dependency. 
