### PR TITLE
Prevent infinitely recurring allocation tracking.

### DIFF
--- a/examples/deadlock.rs
+++ b/examples/deadlock.rs
@@ -1,0 +1,45 @@
+
+use std::{
+    alloc::System,
+};
+use tracking_allocator::{
+    AllocationGroupId, AllocationRegistry, AllocationTracker, Allocator,
+};
+use tracing::{trace, trace_span, subscriber};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<System> = Allocator::system();
+
+struct AllocatingTracker;
+
+impl AllocationTracker for AllocatingTracker {
+    fn allocated(&self, addr: usize, size: usize, _group_id: AllocationGroupId) {
+        trace!{
+            size = size,
+            addr = addr,
+            "alloc"
+        };
+    }
+
+    fn deallocated(&self, addr: usize, _current_group_id: AllocationGroupId) {
+        trace!{
+            addr = addr,
+            "free"
+        };
+    }
+}
+
+fn main() {
+    let _ = AllocationRegistry::set_global_tracker(AllocatingTracker)
+        .expect("no other global tracker should be set");
+
+    subscriber::set_global_default(subscriber::NoSubscriber::default())
+        .expect("setting tracing default failed");
+
+    AllocationRegistry::enable_tracking();
+
+    // uncommenting the next line avoids the deadlock:
+    // let _ = std::io::Write::flush(&mut std::io::stdout());
+
+    trace_span!("test");
+}

--- a/tests/reentrancy.rs
+++ b/tests/reentrancy.rs
@@ -1,0 +1,57 @@
+//! The `allocated` and `deallocated` methods of the `AllocationTracker` used in this test, 
+//! themselves, allocate. This test ensures that these allocations do not lead to infinite
+//! recursion.
+
+use std::{
+    alloc::System,
+    sync::atomic::{AtomicU64, Ordering},
+};
+use tracking_allocator::{
+    AllocationGroupId, AllocationGroupToken, AllocationRegistry, AllocationTracker, Allocator,
+};
+
+#[global_allocator]
+static ALLOCATOR: Allocator<System> = Allocator::system();
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static DEALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+
+struct AllocatingTracker;
+
+impl AllocationTracker for AllocatingTracker {
+    fn allocated(&self, _addr: usize, _size: usize, _group_id: AllocationGroupId) {
+        ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        let _ = Box::new([0u64; 64]);
+    }
+
+    fn deallocated(&self, _addr: usize, _current_group_id: AllocationGroupId) {
+        DEALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        let _ = Box::new([0u64; 64]);
+    }
+}
+
+#[test]
+fn test() {
+    let _ = AllocationRegistry::set_global_tracker(AllocatingTracker)
+        .expect("no other global tracker should be set");
+    AllocationRegistry::enable_tracking();
+    let local_token =
+        AllocationGroupToken::register().expect("failed to register allocation group");
+    let _guard = local_token.enter();
+
+    let allocations = || ALLOCATIONS.load(Ordering::SeqCst);
+    let deallocations = || DEALLOCATIONS.load(Ordering::SeqCst);
+
+    assert_eq!(0, allocations());
+    assert_eq!(0, deallocations());
+
+    let alloc = Box::new(10); // allocate
+
+    assert_eq!(1, allocations());
+    assert_eq!(0, deallocations());
+
+    drop(alloc); // deallocate
+
+    assert_eq!(1, allocations());
+    assert_eq!(1, deallocations());
+}

--- a/tests/reentrancy.rs
+++ b/tests/reentrancy.rs
@@ -1,4 +1,4 @@
-//! The `allocated` and `deallocated` methods of the `AllocationTracker` used in this test, 
+//! The `allocated` and `deallocated` methods of the `AllocationTracker` used in this test,
 //! themselves, allocate. This test ensures that these allocations do not lead to infinite
 //! recursion.
 


### PR DESCRIPTION
Implements the suggestion of using a thread-local variable to prevent infinite recursion when the user's `AllocationTracker`, itself, allocates.

Instead of a separate variable, this PR reuses `CURRENT_ALLOCATION_TOKEN`. In brief, `Allocator<A>::{alloc,dealloc}` now set `CURRENT_ALLOCATION_TOKEN` to `None`, call `AllocationTracker::{allocated,deallocated}`, then, finally, restore the value of `CURRENT_ALLOCATION_TOKEN`.

This approach is very lightweight: the overhead is, essentially, just two additional writes to an `&mut Option<AllocationGroupId>`. There's no detectable performance regression.

